### PR TITLE
Skip RPC related api test

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ jobs:
     - language: object-c
       osx_image: xcode10.2
       env:
-        - SKIP_RPC_TESTS=1
+        - SKIP_CKB_API_TESTS=1
       before_install:
         - cd faucet-server
       install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,8 @@ jobs:
   include:
     - language: object-c
       osx_image: xcode10.2
+      env:
+        - SKIP_RPC_TESTS=1
       before_install:
         - cd faucet-server
       install:

--- a/faucet-server/Sources/App/Model/User.swift
+++ b/faucet-server/Sources/App/Model/User.swift
@@ -24,13 +24,14 @@ extension User {
     public func save() {
         do {
             let filterResult = userTable.filter(accessTokenExpression == accessToken)
-            if try connection.scalar(filterResult.count) > 0 {
-                try connection.run(filterResult.update(
+            do {
+                try connection.run(userTable.insert(
+                    accessTokenExpression <- accessToken,
                     authorizationDateExpression <- authorizationDate,
                     collectionDateExpression <- collectionDate
                 ))
-            } else {
-                try connection.run(userTable.insert(
+            } catch {
+                try connection.run(filterResult.update(
                     accessTokenExpression <- accessToken,
                     authorizationDateExpression <- authorizationDate,
                     collectionDateExpression <- collectionDate

--- a/faucet-server/Tests/AppTests/Controllers/AuthorizationTests.swift
+++ b/faucet-server/Tests/AppTests/Controllers/AuthorizationTests.swift
@@ -10,11 +10,24 @@ import XCTest
 import Vapor
 
 class AuthorizationTests: XCTestCase {
+    override func invokeTest() {
+        if ProcessInfo().environment["SKIP_RPC_TESTS"] == "1" {
+            return
+        }
+        super.invokeTest()
+    }
+
     override func setUp() {
         super.setUp()
         DispatchQueue.global().async {
             do {
-                try app(.detect(arguments: ["", "--env", "test"])).run()
+                try app(.detect(arguments: ["",
+                                            "--env", "dev",
+                                            "--port", "22333",
+                                            "--node_url", "http://localhost:8114",
+                                            "--github_oauth_client_id", "",
+                                            "--github_oauth_client_secret", ""
+                    ])).run()
             } catch {
                 XCTAssert(false, error.localizedDescription)
             }

--- a/faucet-server/Tests/AppTests/Controllers/AuthorizationTests.swift
+++ b/faucet-server/Tests/AppTests/Controllers/AuthorizationTests.swift
@@ -10,13 +10,6 @@ import XCTest
 import Vapor
 
 class AuthorizationTests: XCTestCase {
-    override func invokeTest() {
-        if ProcessInfo().environment["SKIP_RPC_TESTS"] == "1" {
-            return
-        }
-        super.invokeTest()
-    }
-
     override func setUp() {
         super.setUp()
         DispatchQueue.global().async {
@@ -36,7 +29,7 @@ class AuthorizationTests: XCTestCase {
     }
 
     func testVerify() throws {
-        let request = URLRequest(url: URL(string: "http://localhost:8080/auth/verify")!)
+        let request = URLRequest(url: URL(string: "http://localhost:22333/auth/verify")!)
         let result = try sendSyncRequest(request: request)
         XCTAssertEqual(String(data: result, encoding: .utf8), "{\"status\":-1}")
     }

--- a/faucet-server/Tests/AppTests/Controllers/CKBControllerTests.swift
+++ b/faucet-server/Tests/AppTests/Controllers/CKBControllerTests.swift
@@ -11,7 +11,7 @@ import Vapor
 
 class CKBControllerTests: XCTestCase {
     override func invokeTest() {
-        if ProcessInfo().environment["SKIP_RPC_TESTS"] == "1" {
+        if ProcessInfo().environment["SKIP_CKB_API_TESTS"] == "1" {
             return
         }
         super.invokeTest()

--- a/faucet-server/Tests/AppTests/Controllers/CKBControllerTests.swift
+++ b/faucet-server/Tests/AppTests/Controllers/CKBControllerTests.swift
@@ -10,11 +10,24 @@ import XCTest
 import Vapor
 
 class CKBControllerTests: XCTestCase {
+    override func invokeTest() {
+        if ProcessInfo().environment["SKIP_RPC_TESTS"] == "1" {
+            return
+        }
+        super.invokeTest()
+    }
+
     override func setUp() {
         super.setUp()
         DispatchQueue.global().async {
             do {
-                try app(.detect(arguments: ["", "--env", "dev", "--port", "22333"])).run()
+                try app(.detect(arguments: ["",
+                                            "--env", "dev",
+                                            "--port", "22333",
+                                            "--node_url", "http://localhost:8114",
+                                            "--github_oauth_client_id", "",
+                                            "--github_oauth_client_secret", ""
+                    ])).run()
             } catch {
                 XCTAssert(false, error.localizedDescription)
             }
@@ -22,7 +35,7 @@ class CKBControllerTests: XCTestCase {
         Thread.sleep(forTimeInterval: 2)
     }
 
-    func testVerify() throws {
+    func testGenerateAddress() throws {
         let request = URLRequest(url: URL(string: "http://localhost:22333/ckb/address/random")!)
         let result = try sendSyncRequest(request: request)
         do {


### PR DESCRIPTION
Does it seem that there is no public ckb test node address? 
So skip the relevant test first.